### PR TITLE
Fix jasmine package resolution

### DIFF
--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
@@ -30,5 +30,9 @@ class JasmineRunConfiguration(project: Project, factory: ConfigurationFactory, n
     fun setJasminePackage(nodePackage: NodePackage) {
         _jasminePackage = nodePackage
     }
+
+    override fun checkConfiguration() {
+        selectedJasminePackage().validateForRunConfiguration("jasmine")
+    }
 }
 

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
@@ -20,7 +20,7 @@ class JasmineRunConfiguration(project: Project, factory: ConfigurationFactory, n
     fun selectedJasminePackage(): NodePackage {
         if (_jasminePackage == null) {
             val interpreter = NodeJsLocalInterpreter.tryCast(jasmineRunSettings.nodeJs.resolve(project))
-            val pkg = NodePackage.findPreferredPackage(project, "Jasmine", interpreter)
+            val pkg = NodePackage.findPreferredPackage(project, "jasmine", interpreter)
             _jasminePackage = pkg
             return pkg
         }

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
@@ -1,5 +1,6 @@
 package io.pivotal.intellij.jasmine
 
+import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
 
 class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
@@ -17,5 +18,14 @@ class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
         myFixture.addFileToProject("node_modules/jasmine/package.json", "")
 
         assertEquals("/src/node_modules/jasmine", subject.selectedJasminePackage().systemIndependentPath)
+    }
+
+    fun `test configuration error when jasmine package not set`() {
+        try {
+            subject.checkConfiguration()
+            fail("should throw RuntimeConfigurationError")
+        } catch (re: RuntimeConfigurationError) {
+            assertEquals("Unspecified jasmine package", re.message)
+        }
     }
 }

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
@@ -1,0 +1,21 @@
+package io.pivotal.intellij.jasmine
+
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+
+class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
+
+    private lateinit var subject: JasmineRunConfiguration
+
+    public override fun setUp() {
+        super.setUp()
+
+        val configFactory = JasmineConfigurationType.getInstance().configurationFactories[0]
+        subject = configFactory.createTemplateConfiguration(project) as JasmineRunConfiguration
+    }
+
+    fun `test resolves jasmine package`() {
+        myFixture.addFileToProject("node_modules/jasmine/package.json", "")
+
+        assertEquals("/src/node_modules/jasmine", subject.selectedJasminePackage().systemIndependentPath)
+    }
+}


### PR DESCRIPTION
When running a spec file from `context menu -> Run` the configuration produced does not resolve the jasmine package. This results in the `Test framework quit unexpectedly` error as seen in Issues #2 and #3 

Included a configuration error when the jasmine package is not set
