### PR TITLE
Scope based run configurations

### DIFF
--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineConfigIconProvider.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineConfigIconProvider.kt
@@ -1,0 +1,21 @@
+package io.pivotal.intellij.jasmine
+
+import com.intellij.ide.IconProvider
+import com.intellij.json.psi.JsonFile
+import com.intellij.openapi.project.DumbAware
+import com.intellij.psi.PsiElement
+import com.intellij.util.ObjectUtils
+import icons.JSJasmineIcons
+import io.pivotal.intellij.jasmine.util.JasmineUtil
+import javax.swing.Icon
+
+class JasmineConfigIconProvider : IconProvider(), DumbAware {
+    override fun getIcon(element: PsiElement, flags: Int): Icon? {
+        val jsonFile = ObjectUtils.tryCast(element, JsonFile::class.java) ?: return null
+
+        return when {
+            JasmineUtil.isJasmineConfigFile(jsonFile.virtualFile) -> JSJasmineIcons.Jasmine
+            else -> null
+        }
+    }
+}

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineConfigurationEditor.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineConfigurationEditor.kt
@@ -4,7 +4,6 @@ import com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBro
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterField
 import com.intellij.javascript.nodejs.util.NodePackageField
 import com.intellij.json.JsonFileType
-import com.intellij.lang.javascript.library.JSLibraryUtil
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
@@ -20,6 +19,7 @@ import com.intellij.ui.components.fields.ExpandableTextField
 import com.intellij.util.ui.ComponentWithEmptyText
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.SwingHelper
+import io.pivotal.intellij.jasmine.util.JasmineUtil
 import javax.swing.JComponent
 import javax.swing.JPanel
 
@@ -115,11 +115,7 @@ class JasmineConfigurationEditor(private var project: Project) : SettingsEditor<
 
         val files = FileTypeIndex.getFiles(jsonFileType, scope)
 
-        return files.filter { it != null && it.isValid && !it.isDirectory && isJasmineConfigFile(it.nameSequence) && !JSLibraryUtil.isProbableLibraryFile(it) }
-    }
-
-    private fun isJasmineConfigFile(filename: CharSequence): Boolean {
-        return filename.startsWith("jasmine", true)
+        return files.filter { JasmineUtil.isJasmineConfigFile(it) }
     }
 
     override fun createEditor(): JComponent = rootForm

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineConfigurationEditor.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineConfigurationEditor.kt
@@ -16,12 +16,14 @@ import com.intellij.psi.search.ProjectScope
 import com.intellij.ui.RawCommandLineEditor
 import com.intellij.ui.TextFieldWithHistoryWithBrowseButton
 import com.intellij.ui.components.fields.ExpandableTextField
-import com.intellij.util.ui.ComponentWithEmptyText
-import com.intellij.util.ui.FormBuilder
-import com.intellij.util.ui.SwingHelper
+import com.intellij.util.ui.*
+import io.pivotal.intellij.jasmine.scope.JasmineScope
+import io.pivotal.intellij.jasmine.scope.JasmineScopeView
 import io.pivotal.intellij.jasmine.util.JasmineUtil
-import javax.swing.JComponent
-import javax.swing.JPanel
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import java.awt.GridBagConstraints
+import javax.swing.*
 
 
 class JasmineConfigurationEditor(private var project: Project) : SettingsEditor<JasmineRunConfiguration>() {
@@ -33,6 +35,12 @@ class JasmineConfigurationEditor(private var project: Project) : SettingsEditor<
     private var jasmineExecutableField = createJasmineExecutableField()
     private var jasmineOptionsField = createJasmineOptionsField()
     private var jasmineConfigFileField = createJasmineConfigFileField()
+    private var scopeViewPanel = JPanel(BorderLayout())
+
+    private var scopeButtons = mutableMapOf<JasmineScope, JRadioButton>()
+    private var scopeViews = mutableMapOf<JasmineScope, JasmineScopeView>()
+
+    private var longestLabelWidth = JLabel("Environment variables").preferredSize.width
 
     private var rootForm: JPanel
 
@@ -48,6 +56,9 @@ class JasmineConfigurationEditor(private var project: Project) : SettingsEditor<
                 .addLabeledComponent("Jasmine executable", jasmineExecutableField)
                 .addLabeledComponent("Jasmine &config file", jasmineConfigFileField)
                 .addLabeledComponent("E&xtra Jasmine options", jasmineOptionsField)
+                .addSeparator()
+                .addComponent(createScopeRadioButtonPanel())
+                .addComponent(scopeViewPanel)
                 .panel
     }
 
@@ -93,7 +104,7 @@ class JasmineConfigurationEditor(private var project: Project) : SettingsEditor<
 
         SwingHelper.addHistoryOnExpansion(innerField) {
             innerField.history = emptyList<String>()
-            listPossibleConfigFilesInProject().map {  file ->
+            listPossibleConfigFilesInProject().map { file ->
                 FileUtil.toSystemDependentName(file.path)
             }.sorted()
         }
@@ -118,6 +129,58 @@ class JasmineConfigurationEditor(private var project: Project) : SettingsEditor<
         return files.filter { JasmineUtil.isJasmineConfigFile(it) }
     }
 
+    private fun createScopeRadioButtonPanel(): JPanel {
+        val testScopePanel = JPanel(FlowLayout(FlowLayout.CENTER, JBUI.scale(40), 0))
+        val buttonGroup = ButtonGroup()
+
+        JasmineScope.values().forEach { scope ->
+            val radioButton = JRadioButton(UIUtil.removeMnemonic(scope.label))
+
+            val index = UIUtil.getDisplayMnemonicIndex(scope.label)
+            if (index != -1) {
+                radioButton.setMnemonic(scope.label[index + 1])
+                radioButton.displayedMnemonicIndex = index
+            }
+
+            radioButton.addActionListener { setTestScope(scope) }
+
+            scopeButtons[scope] = radioButton
+            testScopePanel.add(radioButton)
+            buttonGroup.add(radioButton)
+        }
+
+        return testScopePanel
+    }
+
+    private fun setTestScope(scope: JasmineScope) {
+        val scopeView = getScopeView(scope)
+        scopeButtons[scope]?.isSelected = true
+        scopeViewPanel.removeAll()
+        scopeViewPanel.add(scopeView.getComponent(), BorderLayout.CENTER)
+        scopeViewPanel.revalidate()
+        scopeViewPanel.repaint()
+    }
+
+    private fun getScopeView(scope: JasmineScope) = scopeViews.getOrPut(scope) {
+        val scopeView = scope.createView(project)
+
+        // align scope view fields with other fields in editor
+        scopeView.getComponent().add(
+                Box.createHorizontalStrut(longestLabelWidth),
+                GridBagConstraints(
+                        0, GridBagConstraints.RELATIVE,
+                        1, 1,
+                        0.0, 0.0,
+                        GridBagConstraints.EAST,
+                        GridBagConstraints.NONE,
+                        JBUI.insetsRight(UIUtil.DEFAULT_HGAP),
+                        0, 0
+                )
+        )
+
+        scopeView
+    }
+
     override fun createEditor(): JComponent = rootForm
 
     override fun applyEditorTo(config: JasmineRunConfiguration) {
@@ -129,6 +192,12 @@ class JasmineConfigurationEditor(private var project: Project) : SettingsEditor<
                 jasmineExecutable = jasmineExecutableField.text,
                 jasmineConfigFile = jasmineConfigFileField.text,
                 extraJasmineOptions = jasmineOptionsField.text)
+
+        scopeButtons.entries.find { it.value.isSelected }?.run {
+            config.jasmineRunSettings.scope = key
+            getScopeView(key).applyTo(config.jasmineRunSettings)
+        }
+
         config.setJasminePackage(jasminePackageField.selected)
     }
 
@@ -142,5 +211,7 @@ class JasmineConfigurationEditor(private var project: Project) : SettingsEditor<
         jasmineExecutableField.text = runSettings.jasmineExecutable
         jasmineConfigFileField.text = runSettings.jasmineConfigFile
         jasmineOptionsField.text = runSettings.extraJasmineOptions
+        setTestScope(runSettings.scope)
+        getScopeView(runSettings.scope).resetFrom(runSettings)
     }
 }

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
@@ -6,7 +6,10 @@ import com.intellij.execution.configurations.LocatableConfigurationBase
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.javascript.nodejs.interpreter.local.NodeJsLocalInterpreter
 import com.intellij.javascript.nodejs.util.NodePackage
+import com.intellij.javascript.testFramework.util.JsTestFqn
 import com.intellij.openapi.project.Project
+import com.intellij.util.PathUtil
+import io.pivotal.intellij.jasmine.scope.JasmineScope
 
 
 class JasmineRunConfiguration(project: Project, factory: ConfigurationFactory, name: String) : LocatableConfigurationBase(project, factory, name) {
@@ -33,6 +36,17 @@ class JasmineRunConfiguration(project: Project, factory: ConfigurationFactory, n
 
     override fun checkConfiguration() {
         selectedJasminePackage().validateForRunConfiguration("jasmine")
+    }
+
+    override fun suggestedName(): String? = when (jasmineRunSettings.scope) {
+        JasmineScope.ALL -> "All Tests"
+        JasmineScope.SPEC_FILE -> PathUtil.getFileName(jasmineRunSettings.specFile)
+        JasmineScope.SUITE, JasmineScope.TEST -> JsTestFqn.getPresentableName(jasmineRunSettings.testNames)
+    }
+
+    override fun getActionName(): String? = when (jasmineRunSettings.scope) {
+        JasmineScope.SUITE, JasmineScope.TEST -> jasmineRunSettings.testNames.lastOrNull()
+        else -> super.getActionName()
     }
 }
 

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
@@ -30,5 +30,9 @@ class JasmineRunConfiguration(project: Project, factory: ConfigurationFactory, n
     fun setJasminePackage(nodePackage: NodePackage) {
         _jasminePackage = nodePackage
     }
+
+    override fun checkConfiguration() {
+        selectedJasminePackage().validateForRunConfiguration("jasmine")
+    }
 }
 

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
@@ -10,6 +10,8 @@ import com.intellij.javascript.testFramework.util.JsTestFqn
 import com.intellij.openapi.project.Project
 import com.intellij.util.PathUtil
 import io.pivotal.intellij.jasmine.scope.JasmineScope
+import io.pivotal.intellij.jasmine.util.JasmineSerializationUtil
+import org.jdom.Element
 
 
 class JasmineRunConfiguration(project: Project, factory: ConfigurationFactory, name: String) : LocatableConfigurationBase(project, factory, name) {
@@ -47,6 +49,16 @@ class JasmineRunConfiguration(project: Project, factory: ConfigurationFactory, n
     override fun getActionName(): String? = when (jasmineRunSettings.scope) {
         JasmineScope.SUITE, JasmineScope.TEST -> jasmineRunSettings.testNames.lastOrNull()
         else -> super.getActionName()
+    }
+
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        JasmineSerializationUtil.writeXml(element, jasmineRunSettings)
+    }
+
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        jasmineRunSettings = JasmineSerializationUtil.readXml(element)
     }
 }
 

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfiguration.kt
@@ -20,7 +20,7 @@ class JasmineRunConfiguration(project: Project, factory: ConfigurationFactory, n
     fun selectedJasminePackage(): NodePackage {
         if (_jasminePackage == null) {
             val interpreter = NodeJsLocalInterpreter.tryCast(jasmineRunSettings.nodeJs.resolve(project))
-            val pkg = NodePackage.findPreferredPackage(project, "Jasmine", interpreter)
+            val pkg = NodePackage.findPreferredPackage(project, "jasmine", interpreter)
             _jasminePackage = pkg
             return pkg
         }

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationProducer.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationProducer.kt
@@ -4,39 +4,68 @@ import com.google.common.collect.ImmutableList
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.javascript.testing.JsTestRunConfigurationProducer
 import com.intellij.lang.javascript.psi.JSFile
+import com.intellij.lang.javascript.psi.JSTestFileType
 import com.intellij.openapi.util.Ref
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileSystemItem
 import com.intellij.psi.util.PsiUtilCore
-import com.intellij.util.ObjectUtils.tryCast
+import io.pivotal.intellij.jasmine.scope.JasmineScope
 
 class JasmineRunConfigurationProducer : JsTestRunConfigurationProducer<JasmineRunConfiguration>(JasmineConfigurationType.getInstance(), ImmutableList.of("jasmine")) {
     override fun isConfigurationFromCompatibleContext(runConfig: JasmineRunConfiguration, context: ConfigurationContext): Boolean {
-        return findTestFile(runConfig, context) != null
+        val element = context.psiLocation ?: return false
+
+        val thatRunSettings = runConfig.jasmineRunSettings
+        val (_, thisRunSettings) = configureSettingsForElement(element, JasmineRunSettings()) ?: return false
+
+        return thisRunSettings.specFile == thatRunSettings.specFile
     }
 
     override fun setupConfigurationFromCompatibleContext(runConfig: JasmineRunConfiguration, context: ConfigurationContext, sourceElement: Ref<PsiElement>): Boolean {
-        val jsFile = findTestFile(runConfig, context) ?: return false
-        sourceElement.set(jsFile)
-        runConfig.setGeneratedName()
+        val element = context.psiLocation ?: return false
 
+        if (!isTestRunnerPackageAvailableFor(element)) {
+            return false
+        }
+
+        val (testElement, runSettings) = configureSettingsForElement(element, runConfig.jasmineRunSettings) ?: return false
+
+        runConfig.jasmineRunSettings = runSettings
+        sourceElement.set(testElement)
+        runConfig.setGeneratedName()
         return true
     }
 
-    private fun findTestFile(runConfig: JasmineRunConfiguration, context: ConfigurationContext): JSFile? {
-        val element = context.psiLocation ?: return null
-        val currentFile = PsiUtilCore.getVirtualFile(element) ?: return null
-        if (currentFile.isDirectory) {
-            // not sure the right way to run a dir
-            return null
+    private fun configureSettingsForElement(
+            element: PsiElement,
+            templateRunSettings: JasmineRunSettings
+    ): Pair<PsiElement, JasmineRunSettings>? {
+        val elementFile = PsiUtilCore.getVirtualFile(element) ?: return null
+
+        return when (element) {
+            is PsiFile -> createFileRunSettings(element, elementFile, templateRunSettings)
+            else -> null // TODO: All/Suite/Test run settings
         }
+    }
 
-        val psiFile = tryCast(element.containingFile, JSFile::class.java) ?: return null
-        psiFile.testFileType ?: return null
+    private fun createFileRunSettings(
+            element: PsiFileSystemItem,
+            elementFile: VirtualFile,
+            templateRunSettings: JasmineRunSettings
+    ): Pair<PsiElement, JasmineRunSettings>? {
 
-        runConfig.jasmineRunSettings = runConfig.jasmineRunSettings.copy(
-                specFile = currentFile.path
-        )
+        val runSettings =
+                if (element is JSFile && element.testFileType == JSTestFileType.JASMINE) {
+                    templateRunSettings.copy(
+                            scope = JasmineScope.SPEC_FILE,
+                            specFile = elementFile.path
+                    )
+                } else {
+                    return null
+                }
 
-        return psiFile
+        return Pair(element, runSettings)
     }
 }

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunProfileState.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunProfileState.kt
@@ -11,6 +11,7 @@ import com.intellij.execution.testframework.TestConsoleProperties
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
 import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
 import com.intellij.execution.ui.ConsoleView
+import com.intellij.javascript.testFramework.util.JsTestFqn
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.PathUtil
@@ -24,7 +25,7 @@ class JasmineRunProfileState(private var project: Project,
                              private var executor: Executor,
                              environment: ExecutionEnvironment) : CommandLineState(environment) {
 
-    override fun startProcess(): ProcessHandler {
+    public override fun startProcess(): ProcessHandler {
         val runSettings = runConfig.jasmineRunSettings
         val interpreter = runSettings.nodeJs.resolveAsLocal(project)
         val commandLine = GeneralCommandLine()
@@ -53,8 +54,12 @@ class JasmineRunProfileState(private var project: Project,
 
         commandLine.addParameter("--reporter=${findReporterPath()}")
 
-        if (!StringUtils.isBlank(runSettings.specFile)) {
+        if (runSettings.specFile.isNotBlank()) {
             commandLine.addParameter(runSettings.specFile)
+        }
+
+        if (runSettings.testNames.isNotEmpty()) {
+            commandLine.addParameter("--filter=${JsTestFqn.getPresentableName(runSettings.testNames)}")
         }
 
         val processHandler = KillableColoredProcessHandler(commandLine)

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunSettings.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunSettings.kt
@@ -12,6 +12,7 @@ data class JasmineRunSettings(
     var extraJasmineOptions : String = "",
     var jasmineExecutable: String = "bin/jasmine.js",
     var jasmineConfigFile : String = "",
-    var scope : JasmineScope = JasmineScope.SPEC_FILE,
-    var specFile : String = ""
+    var scope : JasmineScope = JasmineScope.ALL,
+    var specFile : String = "",
+    var testNames: List<String> = emptyList()
 )

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunSettings.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunSettings.kt
@@ -2,6 +2,7 @@ package io.pivotal.intellij.jasmine
 
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterRef
+import io.pivotal.intellij.jasmine.scope.JasmineScope
 
 data class JasmineRunSettings(
     var nodeJs : NodeJsInterpreterRef = NodeJsInterpreterRef.createProjectRef(),
@@ -11,5 +12,6 @@ data class JasmineRunSettings(
     var extraJasmineOptions : String = "",
     var jasmineExecutable: String = "bin/jasmine.js",
     var jasmineConfigFile : String = "",
+    var scope : JasmineScope = JasmineScope.SPEC_FILE,
     var specFile : String = ""
 )

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineAllTestsScopeView.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineAllTestsScopeView.kt
@@ -1,0 +1,15 @@
+package io.pivotal.intellij.jasmine.scope
+
+import io.pivotal.intellij.jasmine.JasmineRunSettings
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class JasmineAllTestsScopeView : JasmineScopeView {
+    override fun getComponent(): JComponent {
+        return JPanel()
+    }
+
+    override fun resetFrom(settings: JasmineRunSettings) {}
+
+    override fun applyTo(settings: JasmineRunSettings) {}
+}

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScope.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScope.kt
@@ -1,5 +1,6 @@
 package io.pivotal.intellij.jasmine.scope
 
 enum class JasmineScope {
+    ALL,
     SPEC_FILE
 }

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScope.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScope.kt
@@ -2,5 +2,7 @@ package io.pivotal.intellij.jasmine.scope
 
 enum class JasmineScope {
     ALL,
-    SPEC_FILE
+    SPEC_FILE,
+    SUITE,
+    TEST
 }

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScope.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScope.kt
@@ -1,8 +1,28 @@
 package io.pivotal.intellij.jasmine.scope
 
-enum class JasmineScope {
-    ALL,
-    SPEC_FILE,
-    SUITE,
-    TEST
+import com.intellij.openapi.project.Project
+
+enum class JasmineScope constructor(val label: String) {
+    ALL("&All tests") {
+        override fun createView(project: Project): JasmineScopeView {
+            return JasmineAllTestsScopeView()
+        }
+    },
+    SPEC_FILE("Spec &file") {
+        override fun createView(project: Project): JasmineScopeView {
+            return JasmineSpecFileScopeView(project)
+        }
+    },
+    SUITE("S&uite") {
+        override fun createView(project: Project): JasmineScopeView {
+            return JasmineSuiteScopeView(project)
+        }
+    },
+    TEST("&Test") {
+        override fun createView(project: Project): JasmineScopeView {
+            return JasmineTestScopeView(project)
+        }
+    };
+
+    abstract fun createView(project: Project): JasmineScopeView
 }

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScope.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScope.kt
@@ -1,0 +1,5 @@
+package io.pivotal.intellij.jasmine.scope
+
+enum class JasmineScope {
+    SPEC_FILE
+}

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScopeView.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineScopeView.kt
@@ -1,0 +1,10 @@
+package io.pivotal.intellij.jasmine.scope
+
+import io.pivotal.intellij.jasmine.JasmineRunSettings
+import javax.swing.JComponent
+
+interface JasmineScopeView {
+    fun getComponent(): JComponent
+    fun resetFrom(settings: JasmineRunSettings)
+    fun applyTo(settings: JasmineRunSettings)
+}

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineSpecFileScopeView.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineSpecFileScopeView.kt
@@ -1,0 +1,41 @@
+package io.pivotal.intellij.jasmine.scope
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.util.ui.FormBuilder
+import com.intellij.util.ui.SwingHelper
+import com.intellij.webcore.ui.PathShortener
+import io.pivotal.intellij.jasmine.JasmineRunSettings
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class JasmineSpecFileScopeView(project: Project) : JasmineScopeView {
+    private val specFileField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
+    private val panel: JPanel
+
+    init {
+        PathShortener.enablePathShortening(specFileField.textField, null)
+        SwingHelper.installFileCompletionAndBrowseDialog(
+                project,
+                specFileField,
+                "Select Spec File",
+                FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
+        )
+        panel = FormBuilder().setAlignLabelOnRight(false)
+                .addLabeledComponent("Spec file:", specFileField)
+                .panel
+    }
+
+    override fun getComponent(): JComponent {
+        return panel
+    }
+
+    override fun resetFrom(settings: JasmineRunSettings) {
+        specFileField.text = settings.specFile
+    }
+
+    override fun applyTo(settings: JasmineRunSettings) {
+        settings.specFile = PathShortener.getAbsolutePath(specFileField.textField)
+    }
+}

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineSuiteOrTestScopeView.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/scope/JasmineSuiteOrTestScopeView.kt
@@ -1,0 +1,52 @@
+package io.pivotal.intellij.jasmine.scope
+
+import com.intellij.javascript.testFramework.util.TestFullNameView
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.util.ui.FormBuilder
+import com.intellij.util.ui.SwingHelper
+import com.intellij.webcore.ui.PathShortener
+import io.pivotal.intellij.jasmine.JasmineRunSettings
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+open class JasmineSuiteOrTestScopeView(project: Project,
+                                       testFullNamePopupTitle: String,
+                                       testFullNameLabel: String) : JasmineScopeView {
+    private val specFileField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
+    private val testNameView: TestFullNameView = TestFullNameView(testFullNamePopupTitle)
+    private val panel: JPanel
+
+    init {
+        PathShortener.enablePathShortening(specFileField.textField, null)
+        SwingHelper.installFileCompletionAndBrowseDialog(
+                project,
+                specFileField,
+                "Select Spec File",
+                FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
+        )
+
+        panel = FormBuilder().setAlignLabelOnRight(false)
+                .addLabeledComponent("Spec file:", specFileField)
+                .addLabeledComponent(testFullNameLabel, testNameView.component)
+                .panel
+    }
+
+    override fun getComponent(): JComponent {
+        return panel
+    }
+
+    override fun resetFrom(settings: JasmineRunSettings) {
+        specFileField.text = settings.specFile
+        testNameView.names = settings.testNames
+    }
+
+    override fun applyTo(settings: JasmineRunSettings) {
+        settings.specFile = PathShortener.getAbsolutePath(specFileField.textField)
+        settings.testNames = testNameView.names
+    }
+}
+
+class JasmineSuiteScopeView(project: Project) : JasmineSuiteOrTestScopeView(project, "Edit suite name", "Suite name:")
+class JasmineTestScopeView(project: Project) : JasmineSuiteOrTestScopeView(project, "Edit test name", "Test name:")

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/util/JasmineSerializationUtil.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/util/JasmineSerializationUtil.kt
@@ -1,0 +1,77 @@
+package io.pivotal.intellij.jasmine.util
+
+import com.intellij.execution.configuration.EnvironmentVariablesData
+import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterRef
+import com.intellij.openapi.util.JDOMExternalizerUtil
+import com.intellij.openapi.util.io.FileUtil
+import io.pivotal.intellij.jasmine.JasmineRunSettings
+import io.pivotal.intellij.jasmine.scope.JasmineScope
+import org.jdom.Element
+
+object JasmineSerializationUtil {
+    private const val NODE_INTERPRETER = "node-interpreter"
+    private const val NODE_OPTIONS = "node-options"
+    private const val WORKING_DIR = "working-dir"
+    private const val JASMINE_OPTIONS = "jasmine-options"
+    private const val JASMINE_EXECUTABLE = "jasmine-executable"
+    private const val JASMINE_CONFIG = "jasmine-config"
+    private const val SCOPE = "scope"
+    private const val SPEC_FILE = "spec-file"
+    private const val TEST_NAMES = "test-names"
+    private const val TEST_NAME = "test-name"
+
+    fun writeXml(element: Element, runSettings: JasmineRunSettings) {
+        element.write(NODE_INTERPRETER, runSettings.nodeJs.referenceName)
+        element.write(NODE_OPTIONS, runSettings.nodeOptions)
+        element.writePath(WORKING_DIR, runSettings.workingDir)
+        element.write(JASMINE_OPTIONS, runSettings.extraJasmineOptions)
+        element.writePath(JASMINE_EXECUTABLE, runSettings.jasmineExecutable)
+        element.writePath(JASMINE_CONFIG, runSettings.jasmineConfigFile)
+        element.write(SCOPE, runSettings.scope.name)
+        element.writePath(SPEC_FILE, runSettings.specFile)
+        element.writeTestNames(runSettings.testNames)
+        runSettings.envData.writeExternal(element)
+    }
+
+    private fun Element.write(tagName: String, value: String) {
+        if (value.isNotBlank()) {
+            JDOMExternalizerUtil.writeCustomField(this, tagName, value)
+        }
+    }
+
+    private fun Element.writePath(tagName: String, value: String) {
+        this.write(tagName, FileUtil.toSystemIndependentName(value))
+    }
+
+    private fun Element.writeTestNames(testNames: List<String>) {
+        if (testNames.isNotEmpty()) {
+            val testNamesElement = Element(TEST_NAMES)
+            JDOMExternalizerUtil.addChildrenWithValueAttribute(testNamesElement, TEST_NAME, testNames)
+            this.addContent(testNamesElement)
+        }
+    }
+
+    fun readXml(element: Element): JasmineRunSettings {
+        return JasmineRunSettings(
+                nodeJs = NodeJsInterpreterRef.create(element.read(NODE_INTERPRETER)),
+                nodeOptions = element.read(NODE_OPTIONS),
+                workingDir = element.read(WORKING_DIR),
+                extraJasmineOptions = element.read(JASMINE_OPTIONS),
+                jasmineExecutable = element.read(JASMINE_EXECUTABLE),
+                jasmineConfigFile = element.read(JASMINE_CONFIG),
+                envData = EnvironmentVariablesData.readExternal(element),
+                scope = JasmineScope.valueOf(element.read(SCOPE)),
+                specFile = element.read(SPEC_FILE),
+                testNames = element.readTestNames()
+        )
+    }
+
+    private fun Element.read(tagName: String): String {
+        return JDOMExternalizerUtil.readCustomField(this, tagName) ?: ""
+    }
+
+    private fun Element.readTestNames(): List<String> {
+        val testNamesElement = this.getChild(TEST_NAMES) ?: return emptyList()
+        return JDOMExternalizerUtil.getChildrenValueAttributes(testNamesElement, TEST_NAME)
+    }
+}

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/util/JasmineUtil.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/util/JasmineUtil.kt
@@ -1,0 +1,14 @@
+package io.pivotal.intellij.jasmine.util
+
+import com.intellij.lang.javascript.library.JSLibraryUtil
+import com.intellij.openapi.vfs.VirtualFile
+
+object JasmineUtil {
+    fun isJasmineConfigFile(file: VirtualFile?): Boolean {
+        return file != null &&
+                file.isValid &&
+                !file.isDirectory &&
+                file.nameSequence.startsWith("jasmine", true) &&
+                !JSLibraryUtil.isProbableLibraryFile(file)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,6 +29,7 @@
     <configurationType implementation="io.pivotal.intellij.jasmine.JasmineConfigurationType"/>
     <programRunner implementation="io.pivotal.intellij.jasmine.JasmineRunProgramRunner"/>
     <runConfigurationProducer implementation="io.pivotal.intellij.jasmine.JasmineRunConfigurationProducer"/>
+    <iconProvider implementation="io.pivotal.intellij.jasmine.JasmineConfigIconProvider"/>
   </extensions>
 
   <actions>

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineConfigIconProviderTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineConfigIconProviderTest.kt
@@ -1,0 +1,25 @@
+package io.pivotal.intellij.jasmine
+
+import com.intellij.json.JsonFileType
+import com.intellij.openapi.util.IconLoader.CachedImageIcon
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import org.fest.assertions.Assertions.assertThat
+
+class JasmineConfigIconProviderTest : LightPlatformCodeInsightFixtureTestCase() {
+
+    fun `test shows jasmine icon for jasmine config file`() {
+        val jasmineConfigFile = myFixture.configureByText("jasmine.json", "")
+
+        val jasmineIcon = JasmineConfigIconProvider().getIcon(jasmineConfigFile, 0) as CachedImageIcon
+
+        assertThat(jasmineIcon.toString()).endsWith("/icons/jasmine.png")
+    }
+
+    fun `test does not show jasmine icon on other files`() {
+        val jsonFile = myFixture.configureByText(JsonFileType.INSTANCE, "")
+        val txtNamedJasmine = myFixture.configureByText("jasmine.txt", "")
+
+        assertNull(JasmineConfigIconProvider().getIcon(jsonFile, 0))
+        assertNull(JasmineConfigIconProvider().getIcon(txtNamedJasmine, 0))
+    }
+}

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationProducerTest.kt
@@ -1,0 +1,100 @@
+package io.pivotal.intellij.jasmine
+
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.execution.actions.RunConfigurationProducer
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import io.pivotal.intellij.jasmine.scope.JasmineScope
+import java.io.File
+
+class JasmineRunConfigurationProducerTest : LightPlatformCodeInsightFixtureTestCase() {
+
+    private lateinit var configProducer: RunConfigurationProducer<JasmineRunConfiguration>
+    private lateinit var configFactory: ConfigurationFactory
+
+    public override fun setUp() {
+        super.setUp()
+
+        configProducer = RunConfigurationProducer.getInstance(JasmineRunConfigurationProducer::class.java)
+        configFactory = JasmineConfigurationType.getInstance().configurationFactories[0]
+    }
+
+    override fun getTestDataPath(): String = File("src/test/resources/testData").absolutePath
+
+    fun `test does not setup if jasmine dependency missing`() {
+        val specFile = myFixture.configureByText("App.spec.js", """<caret>describe("suite", function(){})""")
+
+        assertNull(generateRunConfigurationAtCaret(specFile))
+    }
+
+    fun `test creates file scope configuration from jasmine spec file`() {
+        myFixture.copyDirectoryToProject("test-project", "")
+
+        val specFile = myFixture.configureByFile("spec/App.spec.js")
+        val config = generateRunConfiguration(specFile)!!
+
+        val runSettings = config.jasmineRunSettings
+        assertEquals(JasmineScope.SPEC_FILE, runSettings.scope)
+        assertEquals("/src/spec/App.spec.js", runSettings.specFile)
+    }
+
+    fun `test does not setup if not a test file`() {
+        myFixture.copyDirectoryToProject("test-project", "")
+
+        val jsFile = myFixture.configureByFile("App.js")
+        assertNull(generateRunConfiguration(jsFile))
+    }
+
+
+    fun `test configuration not compatible when context not a spec file`() {
+        myFixture.copyDirectoryToProject("test-project", "")
+
+        val jsFileContext = ConfigurationContext(myFixture.configureByFile("App.js"))
+
+        assertConfigNotFromContext(createConfiguration(), jsFileContext)
+    }
+
+    fun `test configuration compatible when context is same spec file`() {
+        myFixture.copyDirectoryToProject("test-project", "")
+
+        val existingConfig = createConfiguration(JasmineRunSettings(
+                specFile = "/src/App.spec.js"
+        ))
+
+        val specFile = myFixture.configureByText("App.spec.js", """<caret>describe("suite", function(){})""")
+        val specFileContext = ConfigurationContext(specFile)
+
+        assertConfigFromContext(existingConfig, specFileContext)
+    }
+
+    private fun generateRunConfigurationAtCaret(specFile: PsiFile): JasmineRunConfiguration? {
+        val elementAtCaret = specFile.elementAtCaret()
+        return generateRunConfiguration(elementAtCaret)
+    }
+
+    private fun generateRunConfiguration(element: PsiElement): JasmineRunConfiguration? {
+        val configFromContext = configProducer.createConfigurationFromContext(ConfigurationContext(element))
+        val config = configFromContext?.configuration ?: return null
+        return config as JasmineRunConfiguration
+    }
+
+    private fun PsiFile.elementAtCaret(): PsiElement {
+        return this.findElementAt(myFixture.caretOffset)!!
+    }
+
+    private fun assertConfigFromContext(config: JasmineRunConfiguration?, context: ConfigurationContext) {
+        assertTrue(configProducer.isConfigurationFromContext(config, context))
+    }
+
+    private fun assertConfigNotFromContext(config: JasmineRunConfiguration?, context: ConfigurationContext) {
+        assertFalse(configProducer.isConfigurationFromContext(config, context))
+    }
+
+    private fun createConfiguration(runSettings: JasmineRunSettings = JasmineRunSettings()): JasmineRunConfiguration {
+        val config = JasmineRunConfiguration(project, configFactory, "")
+        config.jasmineRunSettings = runSettings.copy()
+        return config
+    }
+}

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
@@ -2,7 +2,10 @@ package io.pivotal.intellij.jasmine
 
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.util.io.systemIndependentPath
 import io.pivotal.intellij.jasmine.scope.JasmineScope
+import java.io.File
+import java.nio.file.Files
 
 class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
 
@@ -22,11 +25,56 @@ class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
     }
 
     fun `test configuration error when jasmine package not set`() {
+        assertConfigurationErrorEquals("Unspecified jasmine package", subject)
+    }
+
+    fun `test configuration error when spec file not set`() {
+        subject.jasmineRunSettings = JasmineRunSettings(scope = JasmineScope.SPEC_FILE)
+        assertConfigurationErrorEquals("Unspecified spec file", subject)
+
+        subject.jasmineRunSettings = JasmineRunSettings(scope = JasmineScope.SUITE)
+        assertConfigurationErrorEquals("Unspecified spec file", subject)
+
+        subject.jasmineRunSettings = JasmineRunSettings(scope = JasmineScope.TEST)
+        assertConfigurationErrorEquals("Unspecified spec file", subject)
+    }
+
+    fun `test configuration error when spec file is not a file`() {
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.SPEC_FILE,
+                specFile = "doesnotexist"
+        )
+        assertConfigurationErrorEquals("No such spec file", subject)
+
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.SPEC_FILE,
+                specFile = Files.createTempDirectory("temp-dir").systemIndependentPath
+        )
+        assertConfigurationErrorEquals("No such spec file", subject)
+    }
+
+    fun `test configuration error when suite name not set`() {
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.SUITE,
+                specFile = File.createTempFile("App.spec", ".js").absolutePath
+        )
+        assertConfigurationErrorEquals("Unspecified suite name", subject)
+    }
+
+    fun `test configuration error when test name not set`() {
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.TEST,
+                specFile = File.createTempFile("App.spec", ".js").absolutePath
+        )
+        assertConfigurationErrorEquals("Unspecified test name", subject)
+    }
+
+    private fun assertConfigurationErrorEquals(expectedErrorMessage: String, configuration: JasmineRunConfiguration) {
         try {
-            subject.checkConfiguration()
+            configuration.checkConfiguration()
             fail("should throw RuntimeConfigurationError")
         } catch (re: RuntimeConfigurationError) {
-            assertEquals("Unspecified jasmine package", re.message)
+            assertEquals(expectedErrorMessage, re.message)
         }
     }
 

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
@@ -1,5 +1,6 @@
 package io.pivotal.intellij.jasmine
 
+import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
 
 class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
@@ -17,5 +18,14 @@ class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
         myFixture.addFileToProject("node_modules/jasmine/package.json", "")
 
         assertEquals("/src/node_modules/jasmine", subject.selectedJasminePackage().systemIndependentPath)
+    }
+
+    fun `test configuration error when jasmine package not set`() {
+        try {
+            subject.checkConfiguration()
+            fail("should throw RuntimeConfigurationError")
+        } catch (re: RuntimeConfigurationError) {
+            assertEquals("Unspecified jasmine package", re.message)
+        }
     }
 }

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
@@ -2,6 +2,7 @@ package io.pivotal.intellij.jasmine
 
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import io.pivotal.intellij.jasmine.scope.JasmineScope
 
 class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
 
@@ -27,5 +28,69 @@ class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
         } catch (re: RuntimeConfigurationError) {
             assertEquals("Unspecified jasmine package", re.message)
         }
+    }
+
+    fun `test suggested and action name is 'All Tests' for all scope`() {
+        subject.jasmineRunSettings = JasmineRunSettings(scope = JasmineScope.ALL)
+        subject.setGeneratedName()
+
+        assertEquals("All Tests", subject.suggestedName())
+        assertEquals("All Tests", subject.actionName)
+    }
+
+    fun `test suggested and action name is file name for file scope`() {
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.SPEC_FILE,
+                specFile = "spec/App.spec.js"
+        )
+        subject.setGeneratedName()
+
+        assertEquals("App.spec.js", subject.suggestedName())
+        assertEquals("App.spec.js", subject.actionName)
+    }
+
+    fun `test suggested name is full test name for suite scope`() {
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.SUITE,
+                testNames = listOf("top suite", "nested suite")
+        )
+
+        assertEquals("top suite.nested suite", subject.suggestedName())
+    }
+
+    fun `test suggested name is full test name for test scope`() {
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.TEST,
+                testNames = listOf("suite name", "test name")
+        )
+
+        assertEquals("suite name.test name", subject.suggestedName())
+    }
+
+    fun `test action name is suite name for suite scope`() {
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.SUITE,
+                testNames = listOf("top suite", "nested suite")
+        )
+        subject.setGeneratedName()
+
+        assertEquals("nested suite", subject.actionName)
+    }
+
+    fun `test action name is test name for test scope`() {
+        subject.jasmineRunSettings = JasmineRunSettings(
+                scope = JasmineScope.TEST,
+                testNames = listOf("suite name", "test name")
+        )
+        subject.setGeneratedName()
+
+        assertEquals("test name", subject.actionName)
+    }
+
+    fun `test action name is null for empty test names`() {
+        subject.jasmineRunSettings = JasmineRunSettings(scope = JasmineScope.TEST)
+        subject.setGeneratedName()
+
+        assertNull(subject.actionName)
     }
 }

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationTest.kt
@@ -1,0 +1,21 @@
+package io.pivotal.intellij.jasmine
+
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+
+class JasmineRunConfigurationTest : LightPlatformCodeInsightFixtureTestCase() {
+
+    private lateinit var subject: JasmineRunConfiguration
+
+    public override fun setUp() {
+        super.setUp()
+
+        val configFactory = JasmineConfigurationType.getInstance().configurationFactories[0]
+        subject = configFactory.createTemplateConfiguration(project) as JasmineRunConfiguration
+    }
+
+    fun `test resolves jasmine package`() {
+        myFixture.addFileToProject("node_modules/jasmine/package.json", "")
+
+        assertEquals("/src/node_modules/jasmine", subject.selectedJasminePackage().systemIndependentPath)
+    }
+}

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunProfileStateTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/JasmineRunProfileStateTest.kt
@@ -1,0 +1,76 @@
+package io.pivotal.intellij.jasmine
+
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.executors.DefaultRunExecutor
+import com.intellij.execution.process.KillableColoredProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironmentBuilder
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import io.pivotal.intellij.jasmine.scope.JasmineScope
+import junit.framework.TestCase
+import org.fest.assertions.Assertions.assertThat
+
+class JasmineRunProfileStateTest : LightPlatformCodeInsightFixtureTestCase() {
+
+    private var runExecutor = DefaultRunExecutor()
+    private lateinit var configFactory: ConfigurationFactory
+
+    public override fun setUp() {
+        super.setUp()
+
+        runExecutor = DefaultRunExecutor()
+        configFactory = JasmineConfigurationType.getInstance().configurationFactories[0]
+    }
+
+    fun `test spec file path in command`() {
+        val testFilePath = "/path/to/App.spec.js"
+
+        val testFileCommand = commandLineFromSettings(JasmineRunSettings(
+                scope = JasmineScope.SPEC_FILE,
+                specFile = testFilePath
+        ))
+        val suiteCommand = commandLineFromSettings(JasmineRunSettings(
+                scope = JasmineScope.SUITE,
+                specFile = testFilePath
+        ))
+        val testCommand = commandLineFromSettings(JasmineRunSettings(
+                scope = JasmineScope.TEST,
+                specFile = testFilePath
+        ))
+
+        assertThat(testFileCommand).endsWith(testFilePath)
+        assertThat(suiteCommand).endsWith(testFilePath)
+        assertThat(testCommand).endsWith(testFilePath)
+    }
+
+    fun `test test names added as filter`() {
+        val suiteCommand = commandLineFromSettings(JasmineRunSettings(
+                scope = JasmineScope.SUITE,
+                testNames = listOf("App", "spec", "name with spaces")
+        ))
+        val testCommand = commandLineFromSettings(JasmineRunSettings(
+                scope = JasmineScope.TEST,
+                testNames = listOf("App", "spec", "name with spaces")
+        ))
+
+        assertThat(suiteCommand).endsWith("\"--filter=App.spec.name with spaces\"")
+        assertThat(testCommand).endsWith("\"--filter=App.spec.name with spaces\"")
+    }
+
+    fun `test filter not added when empty test names`() {
+        val noFilterCommand = commandLineFromSettings(JasmineRunSettings(
+                scope = JasmineScope.TEST,
+                testNames = listOf()
+        ))
+
+        assertThat(noFilterCommand).doesNotContain("--filter")
+    }
+
+    private fun commandLineFromSettings(runSettings: JasmineRunSettings = JasmineRunSettings()): String {
+        val config = JasmineRunConfiguration(project, configFactory, "")
+        config.jasmineRunSettings = runSettings.copy()
+
+        val execEnvironment = ExecutionEnvironmentBuilder.create(runExecutor, config).build()
+        val runState = JasmineRunProfileState(project, config, runExecutor, execEnvironment)
+        return (runState.startProcess() as KillableColoredProcessHandler).commandLine
+    }
+}

--- a/src/test/kotlin/io/pivotal/intellij/jasmine/util/JasmineSerializationUtilTest.kt
+++ b/src/test/kotlin/io/pivotal/intellij/jasmine/util/JasmineSerializationUtilTest.kt
@@ -1,0 +1,159 @@
+package io.pivotal.intellij.jasmine.util
+
+import com.intellij.execution.configuration.EnvironmentVariablesData
+import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterRef
+import com.intellij.openapi.util.JDOMUtil
+import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.util.JDOMCompare
+import io.pivotal.intellij.jasmine.JasmineRunSettings
+import io.pivotal.intellij.jasmine.scope.JasmineScope
+import org.jdom.Element
+
+class JasmineSerializationUtilTest : LightPlatformTestCase() {
+
+    private lateinit var actualElement: Element
+    private lateinit var emptyRunSettings: JasmineRunSettings
+
+    public override fun setUp() {
+        super.setUp()
+
+        actualElement = Element("configuration")
+        emptyRunSettings = JasmineRunSettings(
+                nodeJs = NodeJsInterpreterRef.create(""),
+                jasmineExecutable = ""
+        )
+    }
+
+    fun `test saves all properties from run settings`() {
+        val runSettings = emptyRunSettings.copy(
+                nodeJs = NodeJsInterpreterRef.create("node"),
+                nodeOptions = "--no-warnings",
+                workingDir = "\$PROJECT_DIR\$",
+                envData = EnvironmentVariablesData.create(mapOf("ENV_NAME" to "ENV_VALUE"), true),
+                extraJasmineOptions = "--no-color",
+                jasmineExecutable = "jasmine.js",
+                jasmineConfigFile = "\$PROJECT_DIR\$/jasmine.json",
+                scope = JasmineScope.TEST,
+                specFile = "\$PROJECT_DIR\$/spec/App.spec.json",
+                testNames = listOf("suite name", "test name")
+        )
+
+        JasmineSerializationUtil.writeXml(actualElement, runSettings)
+
+        val expectedElement = JDOMUtil.load("""
+            <configuration>
+                <node-interpreter value='node' />
+                <node-options value='--no-warnings' />
+                <working-dir value='${'$'}PROJECT_DIR${'$'}' />
+                <jasmine-options value='--no-color' />
+                <jasmine-executable value='jasmine.js' />
+                <jasmine-config value='${'$'}PROJECT_DIR${'$'}/jasmine.json' />
+                <scope value='TEST' />
+                <spec-file value='${'$'}PROJECT_DIR${'$'}/spec/App.spec.json' />
+                <test-names>
+                    <test-name value='suite name' />
+                    <test-name value='test name' />
+                </test-names>
+                <envs>
+                    <env name='ENV_NAME' value='ENV_VALUE' />
+                </envs>
+            </configuration>
+        """)
+
+        assertEquals(expectedElement, actualElement)
+    }
+
+    fun `test does not save empty properties from run settings`() {
+        JasmineSerializationUtil.writeXml(actualElement, emptyRunSettings)
+
+        val expectedElement = JDOMUtil.load("""
+            <configuration>
+                <scope value='ALL' />
+                <envs />
+            </configuration>
+        """)
+
+        assertEquals(expectedElement, actualElement)
+    }
+
+    fun `test saves system independent paths`() {
+        val runSettings = emptyRunSettings.copy(
+                workingDir = "working\\directory\\path",
+                jasmineExecutable = "jasmine\\executable\\path",
+                jasmineConfigFile = "jasmine\\config\\path",
+                specFile = "test\\file\\path",
+                scope = JasmineScope.SPEC_FILE
+        )
+
+        JasmineSerializationUtil.writeXml(actualElement, runSettings)
+
+        val expectedElement = JDOMUtil.load("""
+            <configuration>
+                <working-dir value='working/directory/path' />
+                <jasmine-executable value='jasmine/executable/path' />
+                <jasmine-config value='jasmine/config/path' />
+                <scope value='SPEC_FILE' />
+                <spec-file value='test/file/path' />
+                <envs />
+            </configuration>
+        """)
+
+        assertEquals(expectedElement, actualElement)
+    }
+
+    private fun assertEquals(expected: Element, actual: Element) {
+        assertTrue("Elements not equal: ${JDOMCompare.diffElements(expected, actual)}",
+                JDOMUtil.areElementsEqual(expected, actual))
+    }
+
+    fun `test reads run settings`() {
+        val configElement = JDOMUtil.load("""
+            <configuration>
+                <node-interpreter value='node' />
+                <node-options value='--no-warnings' />
+                <working-dir value='${'$'}PROJECT_DIR${'$'}' />
+                <jasmine-options value='--no-color' />
+                <jasmine-executable value='jasmine.js' />
+                <jasmine-config value='${'$'}PROJECT_DIR${'$'}/jasmine.json' />
+                <scope value='TEST' />
+                <spec-file value='${'$'}PROJECT_DIR${'$'}/spec/App.spec.json' />
+                <test-names>
+                    <test-name value='suite name' />
+                    <test-name value='test name' />
+                </test-names>
+                <envs>
+                    <env name='ENV_NAME' value='ENV_VALUE' />
+                </envs>
+            </configuration>
+        """)
+
+        val actualSettings = JasmineSerializationUtil.readXml(configElement)
+
+        val expectedSettings = emptyRunSettings.copy(
+                nodeJs = NodeJsInterpreterRef.create("node"),
+                nodeOptions = "--no-warnings",
+                workingDir = "\$PROJECT_DIR\$",
+                envData = EnvironmentVariablesData.create(mapOf("ENV_NAME" to "ENV_VALUE"), true),
+                extraJasmineOptions = "--no-color",
+                jasmineExecutable = "jasmine.js",
+                jasmineConfigFile = "\$PROJECT_DIR\$/jasmine.json",
+                scope = JasmineScope.TEST,
+                specFile = "\$PROJECT_DIR\$/spec/App.spec.json",
+                testNames = listOf("suite name", "test name")
+        )
+
+        assertEquals(expectedSettings, actualSettings)
+    }
+
+    fun `test read handles missing properties`() {
+        val configElement = JDOMUtil.load("""
+            <configuration>
+                <scope value='ALL' />
+            </configuration>
+        """)
+
+        val actualSettings = JasmineSerializationUtil.readXml(configElement)
+
+        assertEquals(emptyRunSettings, actualSettings)
+    }
+}

--- a/src/test/resources/testData/test-project/package.json
+++ b/src/test/resources/testData/test-project/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "jasmine": "^3.2.0"
+  }
+}

--- a/src/test/resources/testData/test-project/spec/App.spec.js
+++ b/src/test/resources/testData/test-project/spec/App.spec.js
@@ -1,0 +1,7 @@
+describe('app', function() {
+    describe('suite', function() {
+        it('test', function() {
+            expect(true).toBeTruthy();
+        });
+    });
+});

--- a/src/test/resources/testData/test-project/spec/CaretOnSuite.spec.js
+++ b/src/test/resources/testData/test-project/spec/CaretOnSuite.spec.js
@@ -1,0 +1,7 @@
+describe('app', function() {
+    describe('<caret>suite', function() {
+        it('test', function() {
+            expect(true).toBeTruthy();
+        });
+    });
+});

--- a/src/test/resources/testData/test-project/spec/CaretOnTest.spec.js
+++ b/src/test/resources/testData/test-project/spec/CaretOnTest.spec.js
@@ -1,0 +1,7 @@
+describe('app', function() {
+    describe('suite', function() {
+        it('<caret>test', function() {
+            expect(true).toBeTruthy();
+        });
+    });
+});

--- a/src/test/resources/testData/test-project/spec/support/jasmine.json
+++ b/src/test/resources/testData/test-project/spec/support/jasmine.json
@@ -1,0 +1,8 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
To be merged after PR #6 

This PR introduces test scopes for run configurations. All configurations can be created through the run configuration editor, or from `context menu -> Run` from the following contexts:

| Scope | Context |
| --- | --- |
| **All Tests** | Jasmine config file (jasmine icon now shown for this file in the project tree) |
| **Spec file** | JavaScript file containing tests |
| **Suite** | `describe` elements |
| **Test** | `it` elements |

