### PR TITLE
Resolve RubyMine 2023.3 incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This adds a new run configuration to IntelliJ (and IntelliJ based IDEs) that run
 ### Configure
 1. In the "Run" menu, click on "Edit Configurations", there should be a new "Jasmine" default configuration
 1. Click the "+" to add a new configuration and select "Jasmine" as the template
-1. Fill in your NodeJS interpreter and select the correct Jasmine package and set any other options you want
+1. Fill in your Node.js interpreter and select the correct Jasmine package and set any other options you want
 1. Run your tests!
 
 ## Development

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 name = IdeaJasmine
 group = io.pivotal.jasmine
-version = 1.8
+version = 1.8.1
 ideaVersion = IU-2022.2.5
 publishChannels = Stable
 

--- a/release_notes/1.0.md
+++ b/release_notes/1.0.md
@@ -1,1 +1,1 @@
-- Run your Jasmine tests right from IntelliJ and see the results in the test console. Support for running single files as well as your full suite. Only works with Jasmine 3.0 More information and issues on github (https://github.com/jasmine/IdeaJasmine)
+- Run your Jasmine tests right from IntelliJ and see the results in the test console. Support for running single files as well as your full suite. Only works with Jasmine 3.0 More information and issues on GitHub (https://github.com/jasmine/IdeaJasmine)

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationProducer.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunConfigurationProducer.kt
@@ -45,10 +45,6 @@ class JasmineRunConfigurationProducer : JsTestRunConfigurationProducer<JasmineRu
     override fun setupConfigurationFromCompatibleContext(runConfig: JasmineRunConfiguration, context: ConfigurationContext, sourceElement: Ref<PsiElement>): Boolean {
         val element = context.psiLocation ?: return false
 
-        if (!isTestRunnerPackageAvailableFor(element, context)) {
-            return false
-        }
-
         val (testElement, runSettings) = configureSettingsForElement(element, runConfig.jasmineRunSettings) ?: return false
 
         runConfig.jasmineRunSettings = runSettings

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunProgramRunner.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/JasmineRunProgramRunner.kt
@@ -8,7 +8,7 @@ import com.intellij.execution.runners.*
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.fileEditor.FileDocumentManager
 
-object JasmineRunProgramRunner : GenericProgramRunner<RunnerSettings>() {
+class JasmineRunProgramRunner : GenericProgramRunner<RunnerSettings>() {
     override fun getRunnerId() = "JasmineJavascriptTestRunnerRun"
 
     override fun canRun(executorId: String, profile: RunProfile): Boolean {

--- a/src/main/kotlin/io/pivotal/intellij/jasmine/util/JasmineUtil.kt
+++ b/src/main/kotlin/io/pivotal/intellij/jasmine/util/JasmineUtil.kt
@@ -1,6 +1,9 @@
 package io.pivotal.intellij.jasmine.util
 
 import com.intellij.lang.javascript.library.JSLibraryUtil
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
 import com.intellij.openapi.vfs.VirtualFile
 
 object JasmineUtil {
@@ -10,5 +13,14 @@ object JasmineUtil {
                 !file.isDirectory &&
                 file.nameSequence.startsWith("jasmine", true) &&
                 !JSLibraryUtil.isProbableLibraryFile(file)
+    }
+
+    /**
+     * This function is here to serve as an aid in troubleshooting during development. It can be used to
+     * display information of interest at various points of execution.
+     */
+    fun notify(message: String) {
+        val notification = Notification("Jasmine Plugin", "Jasmine", message, NotificationType.INFORMATION)
+        Notifications.Bus.notify(notification)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,6 +30,7 @@
     <programRunner implementation="io.pivotal.intellij.jasmine.JasmineRunProgramRunner"/>
     <runConfigurationProducer implementation="io.pivotal.intellij.jasmine.JasmineRunConfigurationProducer"/>
     <iconProvider implementation="io.pivotal.intellij.jasmine.JasmineConfigIconProvider"/>
+    <notificationGroup id="Jasmine Plugin" displayType="BALLOON"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
The main change here is the removal of the `isTestRunnerPackageAvailableFor` test in `JasmineRunConfigurationProducer`. Removal of this test restores the ability to execute Jasmine tests by clicking the gutter icons for suites and individual specs.

Other changes include some spelling corrections and minor source enhancements. A utility function was added to allow for convenient posting of notifications. This mechanism was used to aid in troubleshooting, but all invocations have been removed from the source.

The version number was bumped to 1.8.1.